### PR TITLE
Fix/correction exception httpcommand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require" : {
     "php": ">=5.4",
     "ejsmont-artur/php-circuit-breaker": "0.1.0",
-    "guzzlehttp/guzzle": "5.3.0",
+    "guzzlehttp/guzzle": "5.3.1",
     "psr/log": "1.0.2",
     "psr/simple-cache": "1.0.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "548733ffe1a461369597017759f10d0f",
-    "content-hash": "9d217feb1b97e72d1a359b723c567fd6",
+    "hash": "0f309e194ccfe9b3a9958cd5f4839787",
+    "content-hash": "02de7ab7936b0e58e32848ff52d1af67",
     "packages": [
         {
             "name": "ejsmont-artur/php-circuit-breaker",
@@ -52,16 +52,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.3.0",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "f3c8c22471cb55475105c14769644a49c3262b93"
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f3c8c22471cb55475105c14769644a49c3262b93",
-                "reference": "f3c8c22471cb55475105c14769644a49c3262b93",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/70f1fa53b71c4647bf2762c09068a95f77e12fb8",
+                "reference": "70f1fa53b71c4647bf2762c09068a95f77e12fb8",
                 "shasum": ""
             },
             "require": {
@@ -70,15 +70,9 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
-                "psr/log": "^1.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
@@ -106,7 +100,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-05-20 03:47:55"
+            "time": "2016-07-15 19:28:39"
         },
         {
             "name": "guzzlehttp/ringphp",

--- a/src/Digitick/Foundation/Fuse/Command/Http/HttpCommand.php
+++ b/src/Digitick/Foundation/Fuse/Command/Http/HttpCommand.php
@@ -306,7 +306,7 @@ class HttpCommand extends AbstractCommand
             $this->debug("Send request");
             $response = $this->httpClient->send($request);
         } catch (TransferException $exc) {
-            throw $this->ExceptionFactory($exc);
+            throw $this->exceptionFactory($exc);
         }
 
         $this->statusCode = $response->getStatusCode();
@@ -317,7 +317,7 @@ class HttpCommand extends AbstractCommand
         return $this->content;
     }
 
-    private function ExceptionFactory (TransferException $exc) {
+    private function exceptionFactory (TransferException $exc) {
         $this->error(sprintf("Transfer exception caught. Type : %s, status code = %s, message = %s",
                 get_class($exc),
                 $exc->getCode(),
@@ -374,6 +374,9 @@ class HttpCommand extends AbstractCommand
                     $this->error("Throw exception of type ServerException");
                     $thrownException = new ServerException ($exc->getMessage(), $exc->getCode(), $exc);
             }
+        } else {
+            $this->error("Throw exception of type InternalErrorException");
+            $thrownException = new InternalErrorException($exc->getMessage(), $exc->getCode(), $exc);
         }
 
         return $thrownException;


### PR DESCRIPTION
Certaines exceptions n'étaient pas catchées correctement, du coup, on faisait un throw null, qui masquait l'exception d'origine.